### PR TITLE
Update RS485.cpp

### DIFF
--- a/RS485.cpp
+++ b/RS485.cpp
@@ -42,6 +42,10 @@ byte crc8 (const char *addr)
       inbyte >>= 1;
       }  // end of for
     }  // end of while
+    
+    //ADDED FOR PROBLEMS WITH crc = STX or ETX
+    if(crc==STX || crc==ETX) crc=crc-2;
+    
   return crc;
 }  // end of crc8
 


### PR DESCRIPTION
Added for problems with crc = STX or ETX in Function crc8
before return
Change STX to 245 and ETX to 255

 if(crc==STX || crc==ETX) crc=crc-2;
 return crc;
